### PR TITLE
Ensure empty stream does not cause an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,8 +140,10 @@ module.exports = function(needle, replace, options) {
     }
         
     function end() {
-        fifo.forwardRest();
-        fifo.flush();  
+        if (fifo) {
+            fifo.forwardRest();
+            fifo.flush();     
+        }
         this.queue(null);
     }
     

--- a/test/stream.js
+++ b/test/stream.js
@@ -17,6 +17,12 @@ function r(hay,needle, replace, options) {
     return l;
 }
 
+test('empty haystack', function(t) {
+    t.plan(1);
+
+    t.deepEqual(r([], 'a', 'x'), []);
+});
+
 test('single-byte needle', function (t) {
     t.plan(5);  
 


### PR DESCRIPTION
The transform streams `end()` function currently assumes that fifo has been initialized by the `write(..)` call for the stream transform, however in cases where the stream is completely empty, the `write(..)` method may never be called, this small patch ensures that fifo is only called if it has been initialized.
